### PR TITLE
Add stack layout for tab detail routes

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,16 +1,16 @@
 {
   "expo": {
-    "name": "bolt-expo-nativewind",
-    "slug": "bolt-expo-nativewind",
+    "name": "Mentora",
+    "slug": "mentora",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "myapp",
+    "scheme": "mentora",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.anonymous.boltexponativewind"
+      "bundleIdentifier": "com.examtech.mentora"
     },
     "web": {
       "bundler": "metro",
@@ -26,7 +26,7 @@
       "typedRoutes": true
     },
     "android": {
-      "package": "com.anonymous.boltexponativewind"
+      "package": "com.examtech.mentora"
     }
   }
 }

--- a/app/(tabs)/(stacks)/_layout.tsx
+++ b/app/(tabs)/(stacks)/_layout.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Stack } from 'expo-router';
+
+export default function StacksLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+      }}
+    />
+  );
+}

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Tabs, useRouter } from 'expo-router';
 import { Platform } from 'react-native';
 import { COLORS, FONTS } from '@/utils/constants';
@@ -9,9 +9,19 @@ export default function TabLayout() {
   const { authState } = useAuth();
   const router = useRouter();
 
+  const redirectingRef = useRef(false);
+
   useEffect(() => {
-    if (!authState.isLoading && !authState.user) {
+    const shouldRedirect = !authState.isLoading && !authState.user;
+
+    if (shouldRedirect && !redirectingRef.current) {
+      redirectingRef.current = true;
       router.replace('/');
+      return;
+    }
+
+    if (!shouldRedirect) {
+      redirectingRef.current = false;
     }
   }, [authState.isLoading, authState.user, router]);
 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -71,6 +71,12 @@ export default function TabLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="(stacks)"
+        options={{
+          href: null,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Redirect, Tabs } from 'expo-router';
+import React, { useEffect } from 'react';
+import { Tabs, useRouter } from 'expo-router';
 import { Platform } from 'react-native';
 import { COLORS, FONTS } from '@/utils/constants';
 import { useAuth } from '@/contexts/AuthContext';
@@ -7,9 +7,16 @@ import { LayoutGrid as LayoutGroup, Chrome as Home, ChartLine as LineChart, User
 
 export default function TabLayout() {
   const { authState } = useAuth();
+  const router = useRouter();
 
-  if (!authState.user) {
-    return <Redirect href="/" />;
+  useEffect(() => {
+    if (!authState.isLoading && !authState.user) {
+      router.replace('/');
+    }
+  }, [authState.isLoading, authState.user, router]);
+
+  if (authState.isLoading || !authState.user) {
+    return null;
   }
 
   return (

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -243,12 +243,11 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (!authState.user) {
-      router.replace('/');
       return;
     }
 
     fetchAndProcessStudentResults();
-  }, [authState.user, fetchAndProcessStudentResults, router]);
+  }, [authState.user, fetchAndProcessStudentResults]);
 
   useEffect(() => {
     if (!authState.user?.token) {

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -2,22 +2,18 @@ import React from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, ScrollView } from 'react-native';
 import { COLORS, FONTS, SPACING } from '@/utils/constants';
 import { useAuth } from '@/contexts/AuthContext';
-import { useRouter } from 'expo-router';
 import Header from '@/components/shared/Header';
 import Card from '@/components/ui/Card';
 import { User, School, Bell, Settings, CircleHelp as HelpCircle, LogOut, Book, Calendar } from 'lucide-react-native';
 
 export default function ProfileScreen() {
   const { authState, logout } = useAuth();
-  const router = useRouter();
-  
   if (!authState.user) {
     return null;
   }
   
   const handleLogout = async () => {
     await logout();
-    router.replace('/');
   };
   
   const renderProfileInfo = () => (

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "student-results-app",
+  "name": "mentora",
   "main": "expo-router/entry",
   "version": "1.0.0",
   "private": true,


### PR DESCRIPTION
## Summary
- add a stack layout for the detail routes inside the tabs group so they no longer render as tab items

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_b_68da30ed2c54832e80fd643392afb0cf